### PR TITLE
Some cleanups and lisp fixes

### DIFF
--- a/linkmarks.el
+++ b/linkmarks.el
@@ -33,7 +33,7 @@
 
 
 
-(defun linkmarks--setup ()
+(cl-defun linkmarks--setup ()
   "TODO: Write documentation."
 
   (setq org-outline-path-complete-in-steps nil)
@@ -48,7 +48,7 @@
   (setq org-confirm-elisp-link-function nil)
   (setq safe-local-variable-values '((org-confirm-elisp-link-function . nil))))
 
-(defun linkmarks--in-file ()
+(cl-defun linkmarks--in-file ()
   "TODO: Write documentation."
 
   (linkmarks--setup)
@@ -72,7 +72,7 @@
      collect (list (car target) content))))
 
 ;;;###autoload
-(defun linkmarks-select ()
+(cl-defun linkmarks-select ()
   "TODO: Write documentation."
 
   (interactive)
@@ -83,7 +83,7 @@
     (org-open-link-from-string link)))
 
 ;;;###autoload
-(defun linkmarks-capture ()
+(cl-defun linkmarks-capture ()
   "TODO: Write documentation."
 
   (interactive)

--- a/linkmarks.el
+++ b/linkmarks.el
@@ -4,7 +4,7 @@
 
 ;; Author: Dustin Lacewell <dlacewell@gmail.com>
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "24") (helm "0") (dash "0")
+;; Package-Requires: ((emacs "24") (helm "0") (dash "0") (org "0"))
 ;; Keywords: bookmarks, org
 ;; URL: http://github.com/dustinlacewell/linkmarks
 
@@ -16,6 +16,7 @@
 (require 'seq)
 (require 'helm)
 (require 'dash)
+(require 'org)
 
 
 

--- a/linkmarks.el
+++ b/linkmarks.el
@@ -19,7 +19,16 @@
 
 
 
-(setq linkmarks-file (expand-file-name "~/org/bookmarks.org"))
+;;;###autoload
+(defgroup linkmarks nil
+  "Configuration options for linkmarks."
+  :group 'org)
+
+
+(defcustom linkmarks-file (expand-file-name "~/org/bookmarks.org")
+  "Define linkmarks file to store your bookmarks in."
+  :group 'linkmarks
+  :type 'string)
 
 
 

--- a/linkmarks.el
+++ b/linkmarks.el
@@ -50,13 +50,13 @@
   (with-temp-buffer
     (insert-file-contents linkmarks-file t)
     (org-mode)
-    (beginning-of-buffer)
+    (goto-char (point-min))
     (outline-show-all)
     (cl-loop
      for target in (org-refile-get-targets)
      for element = (progn
                      (goto-char (nth 3 target))
-                     (next-line)
+                     (forward-line)
                      (org-element-context))
      for type = (car element)
      for props = (cadr element)

--- a/linkmarks.el
+++ b/linkmarks.el
@@ -71,6 +71,7 @@
      if (equal 'link type)
      collect (list (car target) content))))
 
+;;;###autoload
 (defun linkmarks-select ()
   "TODO: Write documentation."
 
@@ -81,6 +82,7 @@
           ((_ link) (-first (lambda (i) (equal (car i) choice)) targets)))
     (org-open-link-from-string link)))
 
+;;;###autoload
 (defun linkmarks-capture ()
   "TODO: Write documentation."
 

--- a/linkmarks.el
+++ b/linkmarks.el
@@ -34,6 +34,8 @@
 
 
 (defun linkmarks--setup ()
+  "TODO: Write documentation."
+
   (setq org-outline-path-complete-in-steps nil)
   (setq org-link-frame-setup '((elisp . find-file)
                                (vm . vm-visit-folder-other-frame)
@@ -47,6 +49,8 @@
   (setq safe-local-variable-values '((org-confirm-elisp-link-function . nil))))
 
 (defun linkmarks--in-file ()
+  "TODO: Write documentation."
+
   (linkmarks--setup)
   (with-temp-buffer
     (insert-file-contents linkmarks-file t)
@@ -68,6 +72,8 @@
      collect (list (car target) content))))
 
 (defun linkmarks-select ()
+  "TODO: Write documentation."
+
   (interactive)
   (-let* ((targets (linkmarks--in-file))
           (choices (mapcar 'car targets))
@@ -76,6 +82,8 @@
     (org-open-link-from-string link)))
 
 (defun linkmarks-capture ()
+  "TODO: Write documentation."
+
   (interactive)
   (let ((org-capture-entry '("t" "Bookmark" entry (file "~/org/bookmarks.org")
                              "* %^{Title}\n[[%?]]\n  added: %U" '(:kill-buffer))))

--- a/linkmarks.el
+++ b/linkmarks.el
@@ -1,12 +1,12 @@
-;;; -*- lexical-binding: t -*-
-;;; linkmarks.el --- Org-mode link based bookmarks
+;;; linkmarks.el --- Org-mode link based bookmarks -*- lexical-binding: t; -*-
+
 ;; Copyright (C) 2018 Dustin Lacewell
 
 ;; Author: Dustin Lacewell <dlacewell@gmail.com>
-;; Version: 0.1
+;; Version: 0.1.0
 ;; Package-Requires: ((emacs "24") (helm "0") (dash "0")
-;; Keywords: hydra
-;; URL: http://github.com/dustinlacewell/hera
+;; Keywords: bookmarks, org
+;; URL: http://github.com/dustinlacewell/linkmarks
 
 ;;; Commentary:
 
@@ -17,7 +17,11 @@
 (require 'helm)
 (require 'dash)
 
+
+
 (setq linkmarks-file (expand-file-name "~/org/bookmarks.org"))
+
+
 
 (defun linkmarks--setup ()
   (setq org-outline-path-complete-in-steps nil)
@@ -68,5 +72,8 @@
     (linkmarks--setup)
     (org-capture)))
 
+
+
 (provide 'linkmarks)
+
 ;;; linkmarks.el ends here


### PR DESCRIPTION
So, I've gone through the code.

Setting free variables is bad, so I've defined a custom group. You can find it by doing: `M-x customize-group org` or `M-x customize-group linkmarks`.

Also made sure to require org since you set a bunch of org-vars.

It was missing org as a dep and there was a missing parentheses in the deps declaration

I've also added page breaks to split up parts of the code into "sections": https://stackoverflow.com/a/1576895

I've run through `M-x checkdoc` and fixed up the commentary overall.

The docs for all functions you'll have to write yourself since I don't have the in-depth knowledge of what they do.

I've added autoloads so that user-facing functions are available without loading the entire source file. Same with the defgroup so it's available as a custom group without loading the entire source file.

And I also fixed some common missuse of interactive lisp functions.