### PR TITLE
Completely remove Helm as a dependency

### DIFF
--- a/linkmarks.el
+++ b/linkmarks.el
@@ -3,8 +3,8 @@
 
 ;; Author: Dustin Lacewell <dlacewell@gmail.com>
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "24") (helm "0") (dash "0") (org "0"))
-;; Keywords: bookmarks, org, helm
+;; Package-Requires: ((emacs "24") (dash "0") (org "0"))
+;; Keywords: bookmarks, org
 ;; URL: http://github.com/dustinlacewell/linkmarks
 
 ;;; Commentary:

--- a/linkmarks.org
+++ b/linkmarks.org
@@ -9,8 +9,8 @@
 
   ;; Author: Dustin Lacewell <dlacewell@gmail.com>
   ;; Version: 0.1.0
-  ;; Package-Requires: ((emacs "24") (helm "0") (dash "0") (org "0"))
-  ;; Keywords: bookmarks, org, helm
+  ;; Package-Requires: ((emacs "24") (dash "0") (org "0"))
+  ;; Keywords: bookmarks, org
   ;; URL: http://github.com/dustinlacewell/linkmarks
 
   ;;; Commentary:


### PR DESCRIPTION
Commit 9ca42f4 aimed to remove Helm as a dependency, but Helm still existed in the documentation headers for linkmarks.el and linkmarks.org. As a result, when installing this package via the Doom Emacs package manager `helm` would still be built and installed. My commit just removes the mentions of `helm` from the headers and I no longer see the messages indicating the installation of `helm`! 🎉 

My original `package.el` specification:
```elisp
(package! linkmarks :recipe
  (:host github :repo "dustinlacewell/linkmarks"))
```

My modified `package.el` specification for testing my fork:
```elisp
(package! linkmarks :recipe
  (:host github :repo "FrederickGeek8/linkmarks" :branch "fix-remove-helm")
  :pin "1686703ef529fbb154b1cf692ad41979e8a9a28f")
```

Note that I had to pin my commit in order for Doom to respect that I changed my package origin, but I don't think that this will be necessary once this is merged into master.